### PR TITLE
Use localhost for AdGuard Home healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: dnslow.me-adguardhome
     restart: unless-stopped
     healthcheck:
-      test: nslookup www.google.com || exit 1
+      test: nslookup www.google.com 127.0.0.1 || exit 1
       timeout: 5s
       interval: 60s
       start_period: 10s


### PR DESCRIPTION
Query 127.0.0.1 explicitly in the AdGuardHome healthcheck so it verifies the DNS service served by AdGuard Home inside the container instead of relying on the container's default resolver configuration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/peterdavehello/dnslow.me/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved service health monitoring configuration for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->