### PR TITLE
Update Blocky unfiltered BebasID DoH endpoint

### DIFF
--- a/blocky-dns-proxy-config.yml
+++ b/blocky-dns-proxy-config.yml
@@ -88,7 +88,7 @@ upstreams:
       - https://ns1.flodns.net/dns-query
       - https://ns2.flodns.net/dns-query
       - tcp-tls:dns.neutopia.org
-      - https://dns.bebasid.com/unfiltered
+      - https://unfiltered.dns.bebasid.com/dns-query
       - tcp-tls:unfiltered.dns.bebasid.com
 
 caching:


### PR DESCRIPTION
## Summary

Update Blocky's unfiltered BebasID DoH upstream from the retired
`/unfiltered` path to the documented endpoint:

`https://unfiltered.dns.bebasid.com/dns-query`

This keeps the existing unfiltered policy and changes only the endpoint used
to reach the service.

Reference:
- https://github.com/bebasid/bebasdns#tanpa-disaring-unfiltered

## Validation

- `docker-compose config`
- Restarted the existing Blocky container and confirmed it became healthy
- Verified UDP and TCP DNS queries through `127.0.0.1:5454` with `kdig`
- Confirmed the previous BebasID `/unfiltered` content-type warning no longer
  appears in the latest startup logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Blocky’s BebasID unfiltered DoH upstream from https://dns.bebasid.com/unfiltered to https://unfiltered.dns.bebasid.com/dns-query to use the documented service. Behavior is unchanged (unfiltered policy); only the upstream URL changes, which removes the startup content-type warning.

**Review and rollout**
- One-line change in blocky-dns-proxy-config.yml under upstreams; the `tcp-tls:unfiltered.dns.bebasid.com` entry remains.
- Validate with `docker-compose config`, restart Blocky, and query DNS via 127.0.0.1:5454; logs should show no content-type warning.
- If you maintain a local Blocky config override, update the BebasID DoH URL to https://unfiltered.dns.bebasid.com/dns-query.

<sup>Written for commit ebb0840a24050fc89201260b41730f7b15d6147d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/PeterDaveHello/dnslow.me/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates Blocky’s unfiltered BebasID DNS-over-HTTPS upstream from the retired path to `https://unfiltered.dns.bebasid.com/dns-query`. The configuration parsed successfully, and a real DNS-over-HTTPS lookup through the exact configured URL returned a valid DNS response for `example.com`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the updated upstream is valid YAML and successfully resolves DNS-over-HTTPS requests.

The only changed behavior was exercised against the exact configured endpoint. It returned HTTP 200 with the expected DNS message content type and valid A-record answers.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The independently authored DOH validation script, named Blocky Bebasid DOH validation script, was identified and described as parsing YAML and constructing DNS wire messages.
- The DOH validation script was executed to verify the configured endpoint; it parsed the YAML configuration, located the upstream at line 91, sent an RFC 8484-compatible DNS-over-HTTPS A-record query for example.com, and decoded the DNS wire message.
- The validation run produced a healthy endpoint, returning HTTP 200 with application/dns-message and A-records 104.20.23.154 and 172.66.147.243.

<a href="https://app.greptile.com/trex/runs/18526540/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Update Blocky unfiltered BebasID DoH end..."](https://github.com/peterdavehello/dnslow.me/commit/ebb0840a24050fc89201260b41730f7b15d6147d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52637379)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the DNS-over-HTTPS upstream endpoint to use the unfiltered Bebasid DNS service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->