### PR TITLE
Remove unusable PureDNS, AvastDNS, and Alekberg upstreams

### DIFF
--- a/blocky-dns-proxy-config.yml
+++ b/blocky-dns-proxy-config.yml
@@ -68,8 +68,6 @@ upstreams:
       - https://ordns.he.net/dns-query
       - tcp-tls:dns.hostux.net
       - https://dns.hostux.net/dns-query
-      - tcp-tls:puredns.org
-      - https://puredns.org/dns-query
       - tcp-tls:www.morbitzer.de
       - https://www.morbitzer.de/dns-query
       - tcp-tls:ns1.opennameserver.org
@@ -83,8 +81,6 @@ upstreams:
       - https://pluton.plan9-dns.com/dns-query
       - https://helios.plan9-dns.com/dns-query
       - https://kronos.plan9-dns.com/dns-query
-      - https://secure.avastdns.com/dns-query
-      - https://dnsse.alekberg.net/dns-query
       - https://ns1.flodns.net/dns-query
       - https://ns2.flodns.net/dns-query
       - tcp-tls:dns.neutopia.org


### PR DESCRIPTION
PureDNS has no A or AAAA records, and secure.avastdns.com returns NXDOMAIN, so Blocky cannot reach their configured endpoints.

dnsse.alekberg.net no longer answers DoH requests.

References:
- https://dns.google/resolve?name=puredns.org&type=A
- https://dns.google/resolve?name=puredns.org&type=AAAA
- https://dns.google/resolve?name=secure.avastdns.com&type=A
- https://rdap.verisign.com/net/v1/domain/alekberg.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed several DNS upstream servers from the default group.
  * Updated default DNS routing to rely on the remaining configured upstreams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unreachable PureDNS, AvastDNS, and Alekberg upstreams from `blocky-dns-proxy-config.yml` to prevent failed DNS queries. Previously Blocky attempted to use these endpoints, causing timeouts; now they are omitted to improve reliability.

**Review and rollout**
- Reason: `puredns.org` has no A/AAAA records; `secure.avastdns.com` returns NXDOMAIN; `dnsse.alekberg.net` no longer answers DoH.
- Review: Confirm only the four upstream entries were deleted and no references remain elsewhere.
- Rollout: No action for default deployments. If you override upstreams, remove or replace any references to `puredns.org`, `secure.avastdns.com`, or `dnsse.alekberg.net`.

<sup>Written for commit 24563006e70b51cfadce7586836a3c6235f5c449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/PeterDaveHello/dnslow.me/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes four unreachable resolver endpoints from Blocky’s default upstream pool: PureDNS DoT and DoH, AvastDNS DoH, and Alekberg DoH.

A before-and-after configuration check parsed both revisions, confirmed that the default upstream group remains a nonempty string list, retained representative Google, Quad9, and Cloudflare resolvers, and verified that exactly the four intended endpoints were removed. No defects were found.

### T-Rex validation blocked
Native service startup and live DNS-query validation could not run because the required tools are missing: Docker, Docker Compose, Podman, and the Blocky executable are unavailable.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the validated configuration structure and targeted endpoint removals.

There are no final findings. The executed before-and-after YAML validation confirmed a valid nonempty default resolver list, preserved representative providers, and removed only the four intended endpoints.

**Files Needing Attention:** No files need further attention. A native Blocky container startup can be performed later in an environment with Docker and the Blocky runtime available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a native Blocky startup and live DNS-query validation, but execution could not proceed because Docker, Docker Compose, Podman, and the Blocky executable were unavailable.
- T-Rex confirmed that the configuration-level before-and-after check completed successfully despite the missing runtime tooling.

<a href="https://app.greptile.com/trex/runs/18763745/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove unusable PureDNS, AvastDNS, and A..."](https://github.com/peterdavehello/dnslow.me/commit/24563006e70b51cfadce7586836a3c6235f5c449) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53093823)</sub>

<!-- /greptile_comment -->